### PR TITLE
Fix export issue with react native packager

### DIFF
--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -1,1 +1,1 @@
-export Center from "./components/CenterWrapper";
+export { Center } from "./components/CenterWrapper";


### PR DESCRIPTION
When generating a release for android (not with the expo method), the packager complains.
